### PR TITLE
Removed Doctype, head, and body opening and closing tags from forum_page and invalid_page

### DIFF
--- a/FrontEnd/Website/views/forum_page.ejs
+++ b/FrontEnd/Website/views/forum_page.ejs
@@ -1,12 +1,4 @@
-<!DOCTYPE html>
-<html>
-<head>
 
-	<link rel="stylesheet" type="text/css" href="/stylesheets/footer.css">
-	<link rel="stylesheet" type="text/css" href="/stylesheets/global.css">
-</head>
-
-<body>
 
 	<!-- The main object loaded is referenced by "forum" -->
 
@@ -77,5 +69,3 @@
 	
 	<% include partials/footer %>
 
-</body>
-</html>

--- a/FrontEnd/Website/views/invalid_page.ejs
+++ b/FrontEnd/Website/views/invalid_page.ejs
@@ -1,16 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
 
-	<link rel="stylesheet" type="text/css" href="/stylesheets/footer.css">
-	<link rel="stylesheet" type="text/css" href="/stylesheets/global.css">
-</head>
+<!-- The main object loaded is referenced by "forum" -->
 
-<body>
-
-	<!-- The main object loaded is referenced by "forum" -->
-
-    <% include partials/header %>
+ <% include partials/header %>
 	
 	<div class="body-container">
 		<div class="content-container center-div">
@@ -24,7 +15,5 @@
 		</div>
 	</div>
 	
-	<% include partials/footer %>
+<% include partials/footer %>
 
-</body>
-</html>


### PR DESCRIPTION
DOCTYPE, head, and body tags redundant since they are imported in the header and footer partials.