### PR TITLE
Fixed the buggy package.json file by re-adding a comma that was mistakenly deleted

### DIFF
--- a/FrontEnd/Website/package.json
+++ b/FrontEnd/Website/package.json
@@ -15,7 +15,7 @@
     "ejs": "^2.5.7",
     "express": "^4.16.2",
     "nodemailer": "^4.6.0"
-  }
+  },
     "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.0.1"


### PR DESCRIPTION
A comma was mistakenly deleted while editing the package.json file needed for site dependencies. 
It has been re-added.
NPM commands should now work.